### PR TITLE
Remove the slide about obsolete best practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -1081,12 +1081,6 @@ var_dump($city->getCountry());
                     <h2><span class="zf-color">Good Practices</span></h2>
                 </section>
                 <section>
-                    <h2>Keep <span class="doctrine-color">Entities</span> simple</h2>
-                    <p class="fragment">Think of entities as value-objects + ID</p>
-                    <p class="fragment">Don't add logic to entities (it's data!)</p>
-                    <p class="fragment">Keep entities aware only of themselves + associations</p>
-                </section>
-                <section>
                     <h2><span class="doctrine-color">doctrine/common</span> API</h2>
                     <p class="fragment">
                         Stick with the <span class="doctrine-color">doctrine/common</span> interfaces


### PR DESCRIPTION
Entities as value objects is no longer a best practice and confuses people who are trying to read slides now

Submodule on https://github.com/Ocramius/ocramius.github.com will also need to be updated and site regenerated